### PR TITLE
Fix DB module import paths

### DIFF
--- a/Server/Controllers/authController.js
+++ b/Server/Controllers/authController.js
@@ -1,6 +1,6 @@
 require("dotenv").config();
 const bcrypt = require("bcrypt");
-const db = require("../db");
+const db = require("../config/db");
 const jwt = require("jsonwebtoken");
 const JWT_SECRET = process.env.JWT_SECRET;
 

--- a/Server/server.js
+++ b/Server/server.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const path = require("path");
-const db = require("./db");
+const db = require("./config/db");
 const { createProxyMiddleware } = require("http-proxy-middleware");
 const authRoutes = require("./Routes/authRoutes");
 const cookieParser = require("cookie-parser");


### PR DESCRIPTION
## Summary
- load DB module from `config/db` in the server entry file
- adjust auth controller to use the same DB module

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684654542e2883308b5b909e391da3f3